### PR TITLE
feat: make `isSuperAdmin` user method optional

### DIFF
--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -114,12 +114,7 @@ class BasePolicy {
      */
     protected function hasPermissionTo($user, $permission)
     {
-        $class = get_class($user);
-
-        if (! method_exists($user, 'isSuperAdmin')) {
-            throw new \Exception("$class must have isSuperAdmin method declared");
-        }
-
-        return $user->isSuperAdmin() || $user->hasPermissionTo($this->buildPermission($permission));
+        return (method_exists($user, 'isSuperAdmin') && $user->isSuperAdmin()) 
+            || $user->hasPermissionTo($this->buildPermission($permission));
     }
 }


### PR DESCRIPTION
I do not see the necessity to have a super admin account. 

I can see this as a viable option but not for everyone. 

For example I use a "permission-manager" role, and no "super-admin".

_Feel free to close if you think this doesn't belong here._