### PR TITLE
hide perm/role from navigation

### DIFF
--- a/src/Nova/Permission.php
+++ b/src/Nova/Permission.php
@@ -15,6 +15,8 @@ use Spatie\Permission\Models\Permission as PermissionModel;
  */
 class Permission extends Resource
 {
+    public static $displayInNavigation = false;
+    public static $perPageOptions = [50, 200, 500, 1000];
 
     /**
      * The list of field name that should be hidden

--- a/src/Nova/Role.php
+++ b/src/Nova/Role.php
@@ -12,6 +12,8 @@ use Sereny\NovaPermissions\Models\Role as RoleModel;
 
 class Role extends Resource
 {
+    public static $displayInNavigation = false;
+    public static $perPageOptions = [50, 200, 500, 1000];
 
     /**
      * The list of field name that should be hidden


### PR DESCRIPTION
Stops Roles and Permissions being shown twice in sidebar.