### PR TITLE
Permission seeder user path

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,1 +1,0 @@
-Keltron

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,1 @@
+Keltron

--- a/README.md
+++ b/README.md
@@ -6,15 +6,14 @@ We have a Migration, Seed, Policy and Resource ready for a good Authorization Ex
 
 1. [Installation](#Installation)
 2. [Permissions with Groups](#permissions-with-groups)
-    * [Index view](#index-view)
-    * [Detail View](#detail-view)
-    * [Edit View](#edit-view)
-    * [Database Seeding](#database-seeding)
-    * [Create a Model Policy](#create-a-model-policy)
-    * [Super Admin](#super-admin)
+   - [Index view](#index-view)
+   - [Detail View](#detail-view)
+   - [Edit View](#edit-view)
+   - [Database Seeding](#database-seeding)
+   - [Create a Model Policy](#create-a-model-policy)
+   - [Super Admin](#super-admin)
 3. [Customization](#customization)
 4. [Credits](#credits)
-
 
 ## Installation
 
@@ -118,7 +117,6 @@ A new menu item called **Roles & Permissions** will appear in your Nova app afte
 
 ![image](/.github/images/role-edit.png)
 
-
 ### Database Seeding
 
 Publish our Seeder with the following command:
@@ -126,7 +124,6 @@ Publish our Seeder with the following command:
 ```
 php artisan vendor:publish --provider="Sereny\NovaPermissions\ToolServiceProvider" --tag="seeders"
 ```
-
 
 This is just an example on how you could seed your Database with Roles and Permissions. Modify `RolesAndPermissionsSeeder.php` in `database/seeders`. List all your Models you want to have Permissions for in the `$collection` Array and change the email for the Super-Admin:
 
@@ -176,7 +173,7 @@ class RolesAndPermissionsSeeder extends Seeder
         $role->givePermissionTo(Permission::all());
 
         // Give User Super-Admin Role
-        $user = App\User::whereEmail('your@email.com')->first(); // enter your email here
+        $user = \App\Models\User::where('email', 'your@email.com')->first(); // enter your email here
         $user->assignRole('super-admin');
     }
 }
@@ -209,6 +206,7 @@ class ContactPolicy extends BasePolicy
     public $key = 'contact';
 }
 ```
+
 It should now work as exptected. Just create a Role, modify its Permissions and the Policy should take care of the rest.
 
 > **Note**: Don't forget to add your Policy to your `$policies` in `App\Providers\AuthServiceProvider`.
@@ -332,9 +330,6 @@ class Role extends BaseRole
 }
 
 ```
-
-
-
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -331,17 +331,6 @@ class Role extends BaseRole
 
 ```
 
-## Contributors
-
-<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-<!-- prettier-ignore-start -->
-<!-- markdownlint-disable -->
-
-<!-- markdownlint-restore -->
-<!-- prettier-ignore-end -->
-
-<!-- ALL-CONTRIBUTORS-LIST:END -->
-
 ## Credits
 
 This Package is inspired by [eminiarts/nova-permissions](https://github.com/eminiarts/nova-permissions).

--- a/README.md
+++ b/README.md
@@ -331,6 +331,17 @@ class Role extends BaseRole
 
 ```
 
+## Contributors
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
 ## Credits
 
 This Package is inspired by [eminiarts/nova-permissions](https://github.com/eminiarts/nova-permissions).

--- a/database/seeders/RolesAndPermissionsSeeder.php.stub
+++ b/database/seeders/RolesAndPermissionsSeeder.php.stub
@@ -43,7 +43,7 @@ class RolesAndPermissionsSeeder extends Seeder
         $role->givePermissionTo(Permission::all());
 
         // Give User Super-Admin Role
-        // $user = App\User::whereEmail('your@email.com')->first(); // Change this to your email.
+        // $user = \App\Models\User::where('email', 'your@email.com')->first(); // Change this to your email.
         // $user->assignRole('super-admin');
     }
 }


### PR DESCRIPTION
### Changes Made

- Fixed the user path and query in RolesAndPermissionsSeeder to ensure accurate user assignment for the 'super-admin' role.


### Changelog
- Updated the user path and query to correctly locate the user for assigning the 'super-admin' role.
- No other changes were made; the fix addresses a specific issue with the user path and query in the seeder.