### PR TITLE
Add Role and Permission Policy Methods to NovaPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.6.2 (2024-07-29)
+
+- Add setter methods for Role and Permission policies.
+
 ## 1.6.1 (2024-05-06)
 
 - Add namespace to seeders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## 1.6.2 (2024-07-29)
 
 - Add setter methods for Role and Permission policies.
-- Add eager loading of permissions relationship on the Role resource.
 
 ## 1.6.1 (2024-05-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.2 (2024-07-29)
 
 - Add setter methods for Role and Permission policies.
+- Add eager loading of permissions relationship on the Role resource.
 
 ## 1.6.1 (2024-05-06)
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ class User {
 
 use App\Nova\Permission;
 use App\Nova\Role;
+use App\Policies\PermissionPolicy;
+use App\Policies\RolePolicy;
 
 // ...
 
@@ -256,6 +258,8 @@ public function tools()
         \Sereny\NovaPermissions\NovaPermissions::make()
             ->roleResource(Role::class)
             ->permissionResource(Permission::class)
+            ->rolePolicy(RolePolicy::class)
+            ->permissionPolicy(PermissionPolicy::class)
             ->disablePermissions()
             ->disableMenu();
             ->hideFieldsFromRole([

--- a/src/Nova/Role.php
+++ b/src/Nova/Role.php
@@ -13,6 +13,13 @@ use Sereny\NovaPermissions\Models\Role as RoleModel;
 class Role extends Resource
 {
     /**
+     * A cache for all permissions. Useful for the index query.
+     *
+     * @var bool
+     */
+    private static $allPermissions = [];
+
+    /**
      * Indicates if the resource should be displayed in the sidebar.
      *
      * @var bool
@@ -56,6 +63,7 @@ class Role extends Resource
      */
     public static $with = [
         'permissions',
+        'users',
     ];
 
     /**
@@ -101,7 +109,7 @@ class Role extends Resource
                 ->toArray()),
 
             Text::make(__('Users'), function () {
-                return $this->users()->count();
+                return $this->users->count();
             })->exceptOnForms(),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
@@ -133,6 +141,10 @@ class Role extends Resource
         /** @var class-string */
         $permissionClass = config('permission.models.permission');
 
-        return $permissionClass::all()->unique('name');
+        if (!static::$allPermissions) {
+            static::$allPermissions = $permissionClass::all()->unique('name');
+        }
+
+        return static::$allPermissions;
     }
 }

--- a/src/Nova/Role.php
+++ b/src/Nova/Role.php
@@ -50,6 +50,15 @@ class Role extends Resource
     public static $title = 'name';
 
     /**
+     * The relationships that should be eager loaded when performing an index query.
+     *
+     * @var array
+     */
+    public static $with = [
+        'permissions',
+    ];
+
+    /**
      * Get the fields displayed by the resource.
      *
      * @param  \Illuminate\Http\Request $request

--- a/src/Nova/Role.php
+++ b/src/Nova/Role.php
@@ -13,13 +13,6 @@ use Sereny\NovaPermissions\Models\Role as RoleModel;
 class Role extends Resource
 {
     /**
-     * A cache for all permissions. Useful for the index query.
-     *
-     * @var bool
-     */
-    private static $allPermissions = [];
-
-    /**
      * Indicates if the resource should be displayed in the sidebar.
      *
      * @var bool
@@ -55,16 +48,6 @@ class Role extends Resource
      * @var string
      */
     public static $title = 'name';
-
-    /**
-     * The relationships that should be eager loaded when performing an index query.
-     *
-     * @var array
-     */
-    public static $with = [
-        'permissions',
-        'users',
-    ];
 
     /**
      * Get the fields displayed by the resource.
@@ -109,7 +92,7 @@ class Role extends Resource
                 ->toArray()),
 
             Text::make(__('Users'), function () {
-                return $this->users->count();
+                return $this->users()->count();
             })->exceptOnForms(),
 
             MorphToMany::make($userResource::label(), 'users', $userResource)
@@ -141,10 +124,6 @@ class Role extends Resource
         /** @var class-string */
         $permissionClass = config('permission.models.permission');
 
-        if (!static::$allPermissions) {
-            static::$allPermissions = $permissionClass::all()->unique('name');
-        }
-
-        return static::$allPermissions;
+        return $permissionClass::all()->unique('name');
     }
 }

--- a/src/NovaPermissions.php
+++ b/src/NovaPermissions.php
@@ -93,6 +93,30 @@ class NovaPermissions extends Tool
     }
 
     /**
+     * Set the role policy class name
+     *
+     * @param  class-string $rolePolicy
+     * @return $this
+     */
+    public function rolePolicy($rolePolicy)
+    {
+        $this->rolePolicy = $rolePolicy;
+        return $this;
+    }
+
+     /**
+     * Set the permission policy class name
+     *
+     * @param  class-string $permissionPolicy
+     * @return $this
+     */
+    public function permissionPolicy($permissionPolicy)
+    {
+        $this->permissionPolicy = $permissionPolicy;
+        return $this;
+    }
+
+    /**
      * Set a callback that should be used to define wich guard names will be available
      *
      * @param  \Closure  $callback


### PR DESCRIPTION
This pull request introduces two new methods to the NovaPermissions class: rolePolicy and permissionPolicy and adds eager loading of permissions relationship on the Role resource.

These additions provide more flexibility in defining custom role and permission policies within the NovaPermissions package and improve the performance of the Role resource index page.

Please review the changes and let me know if there are any issues or suggestions for further improvements. Thank you!